### PR TITLE
message_linksテーブルを追加

### DIFF
--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,6 +1,24 @@
-# setup
+# Prisma
+
+## スキーマに変更を加えるとき
+
+1. `schema.prisma`を変更する
+2. `npx prisma migrate dev --name what_is_this_change`を実行する
+
+## データベースをリセットするとき
 
 ```bash
-pnpm migrate dev
+npx prisma migrate reset
+```
+
+## データベースに初期データを入れるとき
+
+```bash
 pnpm run seed
+```
+
+## データベースの状態を確認するとき
+
+```bash
+npx prisma studio
 ```

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -5,7 +5,13 @@ TODO: 他のPRで`ts-node`が追加されるので、マージされ次第`packa
 ## スキーマに変更を加えるとき
 
 1. `schema.prisma`を変更する
-2. `npx prisma migrate dev --name what_is_this_change`を実行する
+2. `npx prisma migrate dev`を実行する
+3. 以下のようなメッセージが表示されるので、適切な名前を入力する
+
+```bash
+✔ Enter a name for the new migration:
+# 例: add_user_table
+```
 
 ## データベースをリセットするとき
 

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,5 +1,7 @@
 # Prisma
 
+TODO: 他のPRで`ts-node`が追加されるので、マージされ次第`package.json`の`seed`scriptコマンドを`node`から`ts-node`に変更し、`seed/init.mjs`を`seed/init.ts`にリネームする
+
 ## スキーマに変更を加えるとき
 
 1. `schema.prisma`を変更する

--- a/prisma/migrations/20250225110302_add_message_links_table/migration.sql
+++ b/prisma/migrations/20250225110302_add_message_links_table/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "ThreadMember" ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateTable
+CREATE TABLE "MessageLink" (
+    "id" UUID NOT NULL,
+    "messageId" UUID NOT NULL,
+    "url" TEXT NOT NULL,
+    "title" TEXT,
+    "description" TEXT,
+    "ogImageUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MessageLink_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "MessageLink" ADD CONSTRAINT "MessageLink_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "Message"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250226095622_add_updated_at/migration.sql
+++ b/prisma/migrations/20250226095622_add_updated_at/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `updatedAt` on the `ThreadMember` table. All the data in the column will be lost.
+  - Added the required column `updatedAt` to the `Message` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "MessageLink" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "ThreadMember" DROP COLUMN "updatedAt";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,7 +148,6 @@ model ThreadMember {
   userId    String   @db.Uuid
   user      User     @relation(fields: [userId], references: [id])
   createdAt DateTime @default(now())
-  updatedAt DateTime @default(now())
 
   @@id([threadId, userId])
 }
@@ -183,6 +182,7 @@ model Message {
   mentions       Mention[]
   links          MessageLink[]
   createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 }
 
 model Asset {
@@ -255,7 +255,7 @@ model MessageLink {
   description String?
   ogImageUrl  String?
   createdAt   DateTime @default(now())
-  updatedAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 enum UserStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,7 +148,7 @@ model ThreadMember {
   userId    String   @db.Uuid
   user      User     @relation(fields: [userId], references: [id])
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime @default(now())
 
   @@id([threadId, userId])
 }
@@ -181,6 +181,7 @@ model Message {
   pinnedMessages PinnedMessage[]
   bookmarks      Bookmark[]
   mentions       Mention[]
+  links          MessageLink[]
   createdAt      DateTime        @default(now())
 }
 
@@ -243,6 +244,18 @@ model CustomEmoji {
   name        String
   url         String
   createdAt   DateTime  @default(now())
+}
+
+model MessageLink {
+  id          String   @id @default(uuid()) @db.Uuid
+  messageId   String   @db.Uuid
+  message     Message  @relation(fields: [messageId], references: [id])
+  url         String
+  title       String?
+  description String?
+  ogImageUrl  String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now())
 }
 
 enum UserStatus {


### PR DESCRIPTION
close #40 

メッセージに含まれるURLを管理するためのmessage_linksテーブルを生やすPRです。

Prismaのスキーマ変更と、ついでに簡単なREADMEを書きました。