### PR TITLE
シードデータの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write \"./src/**/*.{ts,tsx}\"",
     "lint": "eslint",
     "stylelint": "stylelint \"./src/**/*.css\" --fix",
-    "seed": "npx tsx ./prisma/seed/init.ts"
+    "seed": "npx prisma migrate reset --force & npx tsx ./prisma/seed/init.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write \"./src/**/*.{ts,tsx}\"",
     "lint": "eslint",
     "stylelint": "stylelint \"./src/**/*.css\" --fix",
-    "seed": "node prisma/seed/init.mjs"
+    "seed": "npx tsx ./prisma/seed/init.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,6 +1,20 @@
 # Prisma
 
-TODO: 他のPRで`ts-node`が追加されるので、マージされ次第`package.json`の`seed`scriptコマンドを`node`から`ts-node`に変更し、`seed/init.mjs`を`seed/init.ts`にリネームする
+## データベースに初期データを入れるとき
+
+同時にデータベースのリセットが行われます。
+
+```bash
+pnpm seed
+```
+
+## データベースの状態を確認するとき
+
+Web UIでデータベースに投入されているデータを確認することができます。
+
+```bash
+npx prisma studio
+```
 
 ## スキーマに変更を加えるとき
 
@@ -17,16 +31,4 @@ TODO: 他のPRで`ts-node`が追加されるので、マージされ次第`packa
 
 ```bash
 npx prisma migrate reset
-```
-
-## データベースに初期データを入れるとき
-
-```bash
-pnpm run seed
-```
-
-## データベースの状態を確認するとき
-
-```bash
-npx prisma studio
 ```

--- a/prisma/seed/GFM.txt
+++ b/prisma/seed/GFM.txt
@@ -1,0 +1,317 @@
+### Features
+
+- Support Standard Markdown / CommonMark and GFM(GitHub Flavored Markdown);
+- Full-featured: Real-time Preview, Image (cross-domain) upload, Preformatted text/Code blocks/Tables insert, Code fold, Search replace, Read only, Themes, Multi-languages, L18n, HTML entities, Code syntax highlighting...;
+- Markdown Extras : Support ToC (Table of Contents), Emoji, Task lists, @Links...;
+- Compatible with all major browsers (IE8+), compatible Zepto.js and iPad;
+- Support identification, interpretation, fliter of the HTML tags;
+- Support TeX (LaTeX expressions, Based on KaTeX), Flowchart and Sequence Diagram of Markdown extended syntax;
+- Support AMD/CMD (Require.js & Sea.js) Module Loader, and Custom/define editor plugins;
+
+# Editor.md
+
+![](https://pandao.github.io/editor.md/images/logos/editormd-logo-180x180.png)
+
+![](https://img.shields.io/github/stars/pandao/editor.md.svg) ![](https://img.shields.io/github/forks/pandao/editor.md.svg) ![](https://img.shields.io/github/tag/pandao/editor.md.svg) ![](https://img.shields.io/github/release/pandao/editor.md.svg) ![](https://img.shields.io/github/issues/pandao/editor.md.svg) ![](https://img.shields.io/bower/v/editor.md.svg)
+
+
+**Table of Contents**
+
+[TOCM]
+
+[TOC]
+
+# H1 header
+## H2 header
+### H3 header
+#### H4 header
+##### H5 header
+###### H6 header
+# Heading 1 link [Heading link](https://github.com/pandao/editor.md "Heading link")
+## Heading 2 link [Heading link](https://github.com/pandao/editor.md "Heading link")
+### Heading 3 link [Heading link](https://github.com/pandao/editor.md "Heading link")
+#### Heading 4 link [Heading link](https://github.com/pandao/editor.md "Heading link") Heading link [Heading link](https://github.com/pandao/editor.md "Heading link")
+##### Heading 5 link [Heading link](https://github.com/pandao/editor.md "Heading link")
+###### Heading 6 link [Heading link](https://github.com/pandao/editor.md "Heading link")
+
+## Headers (Underline)
+
+H1 Header (Underline)
+=============
+
+H2 Header (Underline)
+-------------
+
+### Characters
+                
+----
+
+~~Strikethrough~~ <s>Strikethrough (when enable html tag decode.)</s>
+*Italic*      _Italic_
+**Emphasis**  __Emphasis__
+***Emphasis Italic*** ___Emphasis Italic___
+
+Superscript: X<sub>2</sub>，Subscript: O<sup>2</sup>
+
+**Abbreviation(link HTML abbr tag)**
+
+The <abbr title="Hyper Text Markup Language">HTML</abbr> specification is maintained by the <abbr title="World Wide Web Consortium">W3C</abbr>.
+
+### Blockquotes
+
+> Blockquotes
+
+Paragraphs and Line Breaks
+                    
+> "Blockquotes Blockquotes", [Link](http://localhost/)。
+
+### Links
+
+[Links](http://localhost/)
+
+[Links with title](http://localhost/ "link title")
+
+`<link>` : <https://github.com>
+
+[Reference link][id/name] 
+
+[id/name]: http://link-url/
+
+GFM a-tail link @pandao
+
+### Code Blocks (multi-language) & highlighting
+
+#### Inline code
+
+`$ npm install marked`
+
+#### Code Blocks (Indented style)
+
+Indented 4 spaces, like `<pre>` (Preformatted Text).
+
+    <?php
+        echo "Hello world!";
+    ?>
+    
+Code Blocks (Preformatted text):
+
+    | First Header  | Second Header |
+    | ------------- | ------------- |
+    | Content Cell  | Content Cell  |
+    | Content Cell  | Content Cell  |
+
+#### Javascript
+
+```javascript
+function test(){
+	console.log("Hello world!");
+}
+ 
+(function(){
+    var box = function(){
+        return box.fn.init();
+    };
+
+    box.prototype = box.fn = {
+        init : function(){
+            console.log('box.init()');
+
+			return this;
+        },
+
+		add : function(str){
+			alert("add", str);
+
+			return this;
+		},
+
+		remove : function(str){
+			alert("remove", str);
+
+			return this;
+		}
+    };
+    
+    box.fn.init.prototype = box.fn;
+    
+    window.box =box;
+})();
+
+var testBox = box();
+testBox.add("jQuery").remove("jQuery");
+```
+
+#### HTML code
+
+```html
+<!DOCTYPE html>
+<html>
+    <head>
+        <mate charest="utf-8" />
+        <title>Hello world!</title>
+    </head>
+    <body>
+        <h1>Hello world!</h1>
+    </body>
+</html>
+```
+
+### Images
+
+Image:
+
+![](https://pandao.github.io/editor.md/examples/images/4.jpg)
+
+> Follow your heart.
+
+![](https://pandao.github.io/editor.md/examples/images/8.jpg)
+
+> 图为：厦门白城沙滩 Xiamen
+
+图片加链接 (Image + Link)：
+
+[![](https://pandao.github.io/editor.md/examples/images/7.jpg)](https://pandao.github.io/editor.md/examples/images/7.jpg "李健首张专辑《似水流年》封面")
+
+> 图为：李健首张专辑《似水流年》封面
+                
+----
+
+### Lists
+
+#### Unordered list (-)
+
+- Item A
+- Item B
+- Item C
+     
+#### Unordered list (*)
+
+* Item A
+* Item B
+* Item C
+
+#### Unordered list (plus sign and nested)
+                
++ Item A
++ Item B
+    + Item B 1
+    + Item B 2
+    + Item B 3
++ Item C
+    * Item C 1
+    * Item C 2
+    * Item C 3
+
+#### Ordered list
+                
+1. Item A
+2. Item B
+3. Item C
+                
+----
+                    
+### Tables
+                    
+First Header  | Second Header
+------------- | -------------
+Content Cell  | Content Cell
+Content Cell  | Content Cell 
+
+| First Header  | Second Header |
+| ------------- | ------------- |
+| Content Cell  | Content Cell  |
+| Content Cell  | Content Cell  |
+
+| Function name | Description                    |
+| ------------- | ------------------------------ |
+| `help()`      | Display the help window.       |
+| `destroy()`   | **Destroy your computer!**     |
+
+| Item      | Value |
+| --------- | -----:|
+| Computer  | $1600 |
+| Phone     |   $12 |
+| Pipe      |    $1 |
+
+| Left-Aligned  | Center Aligned  | Right Aligned |
+| :------------ |:---------------:| -----:|
+| col 3 is      | some wordy text | $1600 |
+| col 2 is      | centered        |   $12 |
+| zebra stripes | are neat        |    $1 |
+                
+----
+
+#### HTML entities
+
+&copy; &  &uml; &trade; &iexcl; &pound;
+&amp; &lt; &gt; &yen; &euro; &reg; &plusmn; &para; &sect; &brvbar; &macr; &laquo; &middot; 
+
+X&sup2; Y&sup3; &frac34; &frac14;  &times;  &divide;   &raquo;
+
+18&ordm;C  &quot;  &apos;
+
+## Escaping for Special Characters
+
+\*literal asterisks\*
+
+## Markdown extras
+
+### GFM task list
+
+- [x] GFM task list 1
+- [x] GFM task list 2
+- [ ] GFM task list 3
+    - [ ] GFM task list 3-1
+    - [ ] GFM task list 3-2
+    - [ ] GFM task list 3-3
+- [ ] GFM task list 4
+    - [ ] GFM task list 4-1
+    - [ ] GFM task list 4-2
+
+### Emoji mixed :smiley:
+
+> Blockquotes :star:
+
+#### GFM task lists & Emoji & fontAwesome icon emoji & editormd logo emoji :editormd-logo-5x:
+
+- [x] :smiley: @mentions, :smiley: #refs, [links](), **formatting**, and <del>tags</del> supported :editormd-logo:;
+- [x] list syntax required (any unordered or ordered list supported) :editormd-logo-3x:;
+- [x] [ ] :smiley: this is a complete item :smiley:;
+- [ ] []this is an incomplete item [test link](#) :fa-star: @pandao; 
+- [ ] [ ]this is an incomplete item :fa-star: :fa-gear:;
+    - [ ] :smiley: this is an incomplete item [test link](#) :fa-star: :fa-gear:;
+    - [ ] :smiley: this is  :fa-star: :fa-gear: an incomplete item [test link](#);
+            
+### TeX(LaTeX)
+   
+$$E=mc^2$$
+
+Inline $$E=mc^2$$ Inline，Inline $$E=mc^2$$ Inline。
+
+$$\(\sqrt{3x-1}+(1+x)^2\)$$
+                    
+$$\sin(\alpha)^{\theta}=\sum_{i=0}^{n}(x^i + \cos(f))$$
+                
+### FlowChart
+
+```flow
+st=>start: Login
+op=>operation: Login operation
+cond=>condition: Successful Yes or No?
+e=>end: To admin
+
+st->op->cond
+cond(yes)->e
+cond(no)->op
+```
+
+### Sequence Diagram
+                    
+```seq
+Andrew->China: Says Hello 
+Note right of China: China thinks\nabout it 
+China-->Andrew: How are you? 
+Andrew->>China: I am good thanks!
+```
+
+### End

--- a/prisma/seed/init.ts
+++ b/prisma/seed/init.ts
@@ -1,14 +1,20 @@
+import fs from "fs";
+import path from "path";
+
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
 async function main() {
+  // ワークスペース作成
   const workspace = await prisma.workspace.create({
     data: {
       name: "Digichart for Insider",
       description: "テスト用のワークスペースです",
     },
   });
+
+  // ロール作成
   const adminRole = await prisma.userRole.create({
     data: {
       name: "admin",
@@ -20,31 +26,265 @@ async function main() {
       },
     },
   });
-  const user = await prisma.user.create({
+  const moderatorRole = await prisma.userRole.create({
+    data: {
+      name: "moderator",
+      permissions: {
+        create: true,
+        read: true,
+        update: true,
+        delete: false,
+      },
+    },
+  });
+  const memberRole = await prisma.userRole.create({
+    data: {
+      name: "member",
+      permissions: {
+        create: false,
+        read: true,
+        update: false,
+        delete: false,
+      },
+    },
+  });
+
+  // ユーザー作成
+  const adminUser = await prisma.user.create({
     data: {
       name: "テスト管理者",
       slug: "admin",
-      email: "admin@exmaple.com",
+      email: "admin@example.com",
       image: "https://with.koeni.dev/identicon/admin",
       status: "ONLINE",
       roleId: adminRole.id,
     },
   });
-  const channel = await prisma.channel.create({
+
+  const modUser = await prisma.user.create({
+    data: {
+      name: "モデレーター太郎",
+      slug: "mod-taro",
+      email: "taro@example.com",
+      image: "https://with.koeni.dev/identicon/mod-taro",
+      status: "AWAY",
+      roleId: moderatorRole.id,
+    },
+  });
+
+  const memberUser = await prisma.user.create({
+    data: {
+      name: "一般ユーザー花子",
+      slug: "member-hanako",
+      email: "hanako@example.com",
+      image: "https://with.koeni.dev/identicon/hanako",
+      status: "OFFLINE",
+      roleId: memberRole.id,
+    },
+  });
+
+  const anotherMemberUser = await prisma.user.create({
+    data: {
+      name: "一般ユーザー次郎",
+      slug: "member-jiro",
+      email: "jiro@example.com",
+      image: "https://with.koeni.dev/identicon/jiro",
+      status: "BUSY",
+      roleId: memberRole.id,
+    },
+  });
+
+  // チャンネル作成
+  const generalChannel = await prisma.channel.create({
     data: {
       slug: "general",
       name: "general",
       workspaceId: workspace.id,
       type: "PUBLIC",
+      creatorId: adminUser.id,
+      description: "全体向けの一般チャンネル",
     },
   });
+
+  const randomChannel = await prisma.channel.create({
+    data: {
+      slug: "random",
+      name: "random",
+      workspaceId: workspace.id,
+      type: "PUBLIC",
+      creatorId: modUser.id,
+      description: "雑談用チャンネル",
+    },
+  });
+
+  const privateChannel = await prisma.channel.create({
+    data: {
+      slug: "private",
+      name: "private",
+      workspaceId: workspace.id,
+      type: "PRIVATE",
+      creatorId: adminUser.id,
+      description: "管理者専用チャンネル",
+    },
+  });
+
+  // ----- general チャンネルのメッセージ -----
   await prisma.message.create({
     data: {
       content: "Hello, World!",
-      channelId: channel.id,
-      userId: user.id,
+      channelId: generalChannel.id,
+      userId: adminUser.id,
       type: "NORMAL",
     },
+  });
+
+  await prisma.message.create({
+    data: {
+      content:
+        "This is a *markdown* message with **bold text** and [a link](https://example.com).",
+      channelId: generalChannel.id,
+      userId: modUser.id,
+      type: "IMPORTANT",
+    },
+  });
+
+  await prisma.message.create({
+    data: {
+      content:
+        "Here is some TeX: \\(E = mc^2\\) which explains the famous equation.",
+      channelId: generalChannel.id,
+      userId: memberUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  await prisma.message.create({
+    data: {
+      content:
+        "<p>This is a rich text message with <strong>HTML content</strong> and an image: <img src='https://example.com/image.png' alt='sample'></p>",
+      channelId: generalChannel.id,
+      userId: anotherMemberUser.id,
+      type: "PROJECT",
+    },
+  });
+
+  // URL を含むメッセージを作成し、MessageLink テーブルにもレコードを追加
+  const msgWithURL = await prisma.message.create({
+    data: {
+      content: "Check out our new website: https://digicre.net/",
+      channelId: generalChannel.id,
+      userId: adminUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  await prisma.messageLink.create({
+    data: {
+      messageId: msgWithURL.id,
+      url: "https://digicre.net/",
+      title: "芝浦工業大学 デジクリ",
+      description: "芝浦工業大学の公認サークル『デジクリ』の Web サイトです。",
+      ogImageUrl: "https://digicre.net/ogp.png",
+    },
+  });
+
+  // 様々なパターンが入ったメッセージ
+  const filePath = path.join(__dirname, "GFM.txt");
+  const content = fs.readFileSync(filePath, "utf8");
+  await prisma.message.create({
+    data: {
+      content: content,
+      channelId: generalChannel.id,
+      userId: memberUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  // ----- random チャンネルのメッセージ -----
+  await prisma.message.create({
+    data: {
+      content: "Random talk: Did you see the latest news?",
+      channelId: randomChannel.id,
+      userId: modUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  await prisma.message.create({
+    data: {
+      content: "Another random message with **markdown** and _italic_ style.",
+      channelId: randomChannel.id,
+      userId: memberUser.id,
+      type: "IMPORTANT",
+    },
+  });
+
+  // メンションを含むメッセージ作成（内容中は @ユーザーID と記載）し、Mention テーブルへレコードを追加
+  const mentionMsg = await prisma.message.create({
+    data: {
+      content: `Hello @${adminUser.id}, please review the latest update.`,
+      channelId: randomChannel.id,
+      userId: modUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  await prisma.mention.create({
+    data: {
+      messageId: mentionMsg.id,
+      mentionedUserId: adminUser.id,
+    },
+  });
+
+  // ----- private チャンネルのメッセージ -----
+  await prisma.message.create({
+    data: {
+      content: "管理者専用のシークレットなメッセージです。",
+      channelId: privateChannel.id,
+      userId: adminUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  await prisma.message.create({
+    data: {
+      content:
+        "Another private message with TeX: \\(\\int_0^1 x^2 dx = \\frac{1}{3}\\)",
+      channelId: privateChannel.id,
+      userId: modUser.id,
+      type: "NORMAL",
+    },
+  });
+
+  // ----- 各チャンネルでメッセージを投稿しているユーザーを ChannelMember テーブルに登録 -----
+  // general チャンネル
+  await prisma.channelMember.createMany({
+    data: [
+      { channelId: generalChannel.id, userId: adminUser.id, role: "ADMIN" },
+      { channelId: generalChannel.id, userId: modUser.id, role: "MEMBER" },
+      { channelId: generalChannel.id, userId: memberUser.id, role: "MEMBER" },
+      {
+        channelId: generalChannel.id,
+        userId: anotherMemberUser.id,
+        role: "MEMBER",
+      },
+    ],
+  });
+
+  // random チャンネル
+  await prisma.channelMember.createMany({
+    data: [
+      { channelId: randomChannel.id, userId: modUser.id, role: "MEMBER" },
+      { channelId: randomChannel.id, userId: memberUser.id, role: "MEMBER" },
+    ],
+  });
+
+  // private チャンネル
+  await prisma.channelMember.createMany({
+    data: [
+      { channelId: privateChannel.id, userId: adminUser.id, role: "ADMIN" },
+      { channelId: privateChannel.id, userId: modUser.id, role: "MEMBER" },
+    ],
   });
 }
 

--- a/prisma/seed/init.ts
+++ b/prisma/seed/init.ts
@@ -5,8 +5,8 @@ const prisma = new PrismaClient();
 async function main() {
   const workspace = await prisma.workspace.create({
     data: {
-      name: "Test",
-      description: "A workspace for development",
+      name: "Digichart for Insider",
+      description: "テスト用のワークスペースです",
     },
   });
   const adminRole = await prisma.userRole.create({

--- a/prisma/seed/init.ts
+++ b/prisma/seed/init.ts
@@ -9,7 +9,7 @@ async function main() {
   // ワークスペース作成
   const workspace = await prisma.workspace.create({
     data: {
-      name: "Digichart for Insider",
+      name: "Digichat for Insider",
       description: "テスト用のワークスペースです",
     },
   });


### PR DESCRIPTION
close #41 

Prismaのseedコマンドにリセット処理を追加し、シードデータの種類を増やしました。

- ロール
  - admin, moderator, member
- ユーザー
  - モデレーター太郎, 一般ユーザー花子, 一般ユーザー次郎
- チャンネル
  - general, random, private
- メッセージ
  - シンプルテキスト, Markdown, TeX, HTML, リンク入りメッセージ, GFMのサンプルテキスト
- その他 
  - メッセージに含まれるリンク, メンション
  - チャンネルメンバー

<img width="954" alt="スクリーンショット 2025-04-04 19 01 04" src="https://github.com/user-attachments/assets/13237b5e-62ab-4a8a-b086-c9779093c1c9" />
