### PR TITLE
Feat/参加中チャンネルの表示

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -97,8 +97,18 @@ erDiagram
   String userId FK
   String channelId FK
   ChannelMemberRole role
+  String categoryId FK "nullable"
+  Int displayOrder
   DateTime joinedAt
   DateTime lastAccessedAt
+}
+"ChannelCategory" {
+  String id PK
+  String name
+  String userId FK
+  String workspaceId FK
+  DateTime createdAt
+  DateTime updatedAt
 }
 "Message" {
   String id PK
@@ -175,6 +185,9 @@ erDiagram
 "ThreadMember" }o--|| "User" : user
 "ChannelMember" }o--|| "User" : user
 "ChannelMember" }o--|| "Channel" : channel
+"ChannelMember" }o--o| "ChannelCategory" : category
+"ChannelCategory" }o--|| "User" : user
+"ChannelCategory" }o--|| "Workspace" : workspace
 "Message" }o--|| "Channel" : channel
 "Message" }o--o| "Thread" : thread
 "Message" }o--|| "User" : user
@@ -195,7 +208,8 @@ erDiagram
 ```
 
 ### `Account`
-Google OAuthのアカウントを管理するテーブル。Auth.js用
+*
+ * Google OAuthのアカウントを管理するテーブル。Auth.js用
 
 **Properties**
   - `id`: 
@@ -212,7 +226,8 @@ Google OAuthのアカウントを管理するテーブル。Auth.js用
   - `session_state`: 
 
 ### `Session`
-ログインユーザーのセッションを管理するテーブル。Auth.js用
+*
+ * ログインユーザーのセッションを管理するテーブル。Auth.js用
 
 **Properties**
   - `id`: 
@@ -221,7 +236,8 @@ Google OAuthのアカウントを管理するテーブル。Auth.js用
   - `expires`: 
 
 ### `VerificationToken`
-Auth.js用
+*
+ * Auth.js用
 
 **Properties**
   - `identifier`: 
@@ -229,7 +245,8 @@ Auth.js用
   - `expires`: 
 
 ### `User`
-Digichatユーザーを管理するテーブル
+*
+ * Digichatユーザーを管理するテーブル
 
 **Properties**
   - `id`: 
@@ -246,7 +263,8 @@ Digichatユーザーを管理するテーブル
   - `updatedAt`: 
 
 ### `UserRole`
-ユーザーのロールを管理するテーブル。Discordのロールに相当する
+*
+ * ユーザーのロールを管理するテーブル。Discordのロールに相当する
 
 **Properties**
   - `id`: 
@@ -256,7 +274,8 @@ Digichatユーザーを管理するテーブル
   - `updatedAt`: 
 
 ### `Workspace`
-ワークスペースを管理するテーブル
+*
+ * ワークスペースを管理するテーブル
 
 **Properties**
   - `id`: 
@@ -301,7 +320,8 @@ Digichatユーザーを管理するテーブル
   - `updatedAt`: 
 
 ### `ThreadMember`
-スレッドをフォロー中のユーザーを管理するテーブル。通知を送信する対象
+*
+ * スレッドをフォロー中のユーザーを管理するテーブル。通知を送信する対象
 
 **Properties**
   - `threadId`: 
@@ -314,8 +334,22 @@ Digichatユーザーを管理するテーブル
   - `userId`: 
   - `channelId`: 
   - `role`: 
+  - `categoryId`: 
+  - `displayOrder`: フォルダ内の表示順。同じフォルダ内で並び順の入れ替えが発生したときに更新する
   - `joinedAt`: 
   - `lastAccessedAt`: チャンネルに最後にアクセスした日時。既読の管理に使用
+
+### `ChannelCategory`
+*
+ * ユーザーが作成したフォルダを管理するテーブル
+
+**Properties**
+  - `id`: 
+  - `name`: 
+  - `userId`: 
+  - `workspaceId`: 
+  - `createdAt`: 
+  - `updatedAt`: 
 
 ### `Message`
 
@@ -334,7 +368,7 @@ Digichatユーザーを管理するテーブル
 **Properties**
   - `id`: 
   - `messageId`: 
-  - `alt`: 
+  - `alt`: アセットの代替テキスト。画像の場合はalt属性に相当
   - `type`: 
   - `url`: 
   - `createdAt`: 
@@ -356,7 +390,8 @@ Digichatユーザーを管理するテーブル
   - `pinnedAt`: 
 
 ### `Bookmark`
-ユーザーが個人的にメッセージを保存しておくためのブックマーク機能に使用するテーブル
+*
+ * ユーザーが個人的にメッセージを保存しておくためのブックマーク機能に使用するテーブル
 
 **Properties**
   - `userId`: 

--- a/prisma/migrations/20250412180407_add_channel_category_and_display_order/migration.sql
+++ b/prisma/migrations/20250412180407_add_channel_category_and_display_order/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - Added the required column `displayOrder` to the `ChannelMember` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ChannelMember" ADD COLUMN     "categoryId" UUID,
+ADD COLUMN     "displayOrder" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "ChannelCategory" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "userId" UUID NOT NULL,
+    "workspaceId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChannelCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ChannelMember" ADD CONSTRAINT "ChannelMember_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "ChannelCategory"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChannelCategory" ADD CONSTRAINT "ChannelCategory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChannelCategory" ADD CONSTRAINT "ChannelCategory_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,9 +13,9 @@ datasource db {
   url      = env("POSTGRES_URL")
 }
 
-/*
-Google OAuthのアカウントを管理するテーブル。Auth.js用
-*/
+/**
+ * Google OAuthのアカウントを管理するテーブル。Auth.js用
+ */
 model Account {
   id                String  @id @default(uuid()) @db.Uuid
   userId            String  @map("user_id") @db.Uuid
@@ -35,9 +35,9 @@ model Account {
   @@unique([provider, providerAccountId])
 }
 
-/*
-ログインユーザーのセッションを管理するテーブル。Auth.js用
-*/
+/**
+ * ログインユーザーのセッションを管理するテーブル。Auth.js用
+ */
 model Session {
   id           String   @id @default(uuid()) @db.Uuid
   sessionToken String   @unique @map("session_token")
@@ -47,9 +47,9 @@ model Session {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
-/*
-Auth.js用
-*/
+/**
+ * Auth.js用
+ */
 model VerificationToken {
   identifier String
   token      String
@@ -58,46 +58,47 @@ model VerificationToken {
   @@id([identifier, token])
 }
 
-/*
-Digichatユーザーを管理するテーブル
-*/
+/**
+ * Digichatユーザーを管理するテーブル
+ */
 model User {
-  id              String            @id @default(uuid()) @db.Uuid
+  id                String            @id @default(uuid()) @db.Uuid
   /// ユーザーが自由に設定できる一意なID
-  slug            String            @unique
+  slug              String            @unique
   /// 表示名
-  name            String
+  name              String
   /// 大学のGmailアカウント。sicなし
-  email           String            @unique
-  emailVerified   DateTime?         @map("email_verified")
-  accounts        Account[]
-  sessions        Session[]
+  email             String            @unique
+  emailVerified     DateTime?         @map("email_verified")
+  accounts          Account[]
+  sessions          Session[]
   /// アイコン画像のURL
-  image           String?
+  image             String?
   /// オンライン状態
-  status          UserStatus
+  status            UserStatus
   /// 自己紹介
-  description     String?
-  role            UserRole          @relation(fields: [roleId], references: [id])
-  roleId          String            @db.Uuid
-  verifiedAt      DateTime?
-  workspaces      WorkspaceMember[]
-  createdChannels Channel[]
-  createdThreads  Thread[]
-  threads         ThreadMember[]
-  channels        ChannelMember[]
-  messages        Message[]
-  reactions       Reaction[]
-  pinnedMessages  PinnedMessage[]
-  bookmarks       Bookmark[]
-  mentions        Mention[]
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
+  description       String?
+  role              UserRole          @relation(fields: [roleId], references: [id])
+  roleId            String            @db.Uuid
+  verifiedAt        DateTime?
+  workspaces        WorkspaceMember[]
+  createdChannels   Channel[]
+  createdThreads    Thread[]
+  threads           ThreadMember[]
+  channels          ChannelMember[]
+  channelCategories ChannelCategory[]
+  messages          Message[]
+  reactions         Reaction[]
+  pinnedMessages    PinnedMessage[]
+  bookmarks         Bookmark[]
+  mentions          Mention[]
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
 }
 
-/*
-ユーザーのロールを管理するテーブル。Discordのロールに相当する
-*/
+/**
+ * ユーザーのロールを管理するテーブル。Discordのロールに相当する
+ */
 model UserRole {
   id          String   @id @default(uuid()) @db.Uuid
   name        String
@@ -108,17 +109,18 @@ model UserRole {
   updatedAt   DateTime @updatedAt
 }
 
-/*
-ワークスペースを管理するテーブル
-*/
+/**
+ * ワークスペースを管理するテーブル
+ */
 model Workspace {
-  id           String           @id @default(uuid()) @db.Uuid
-  slug         String           @unique
+  id           String            @id @default(uuid()) @db.Uuid
+  slug         String            @unique
   name         String
   description  String?
   users        WorkspaceMember[]
   channels     Channel[]
   customEmojis CustomEmoji[]
+  categories   ChannelCategory[]
   createdAt    DateTime          @default(now())
   updatedAt    DateTime          @updatedAt
 }
@@ -173,9 +175,9 @@ model Thread {
   updatedAt       DateTime       @updatedAt
 }
 
-/*
-スレッドをフォロー中のユーザーを管理するテーブル。通知を送信する対象
-*/
+/**
+ * スレッドをフォロー中のユーザーを管理するテーブル。通知を送信する対象
+ */
 model ThreadMember {
   threadId  String   @db.Uuid
   thread    Thread   @relation(fields: [threadId], references: [id])
@@ -192,11 +194,31 @@ model ChannelMember {
   channelId      String            @db.Uuid
   channel        Channel           @relation(fields: [channelId], references: [id])
   role           ChannelMemberRole
+  /// 格納されているフォルダ。nullの場合はデフォルトフォルダに格納されていることとする
+  category       ChannelCategory?  @relation(fields: [categoryId], references: [id])
+  categoryId     String?           @db.Uuid
+  /// フォルダ内の表示順。同じフォルダ内で並び順の入れ替えが発生したときに更新する
+  displayOrder   Int
   joinedAt       DateTime          @default(now())
   /// チャンネルに最後にアクセスした日時。既読の管理に使用
   lastAccessedAt DateTime          @default(now())
 
   @@id([channelId, userId])
+}
+
+/**
+ * ユーザーが作成したフォルダを管理するテーブル
+ */
+model ChannelCategory {
+  id             String          @id @default(uuid()) @db.Uuid
+  name           String
+  userId         String          @db.Uuid
+  user           User            @relation(fields: [userId], references: [id])
+  workspaceId    String          @db.Uuid
+  workspace      Workspace       @relation(fields: [workspaceId], references: [id])
+  channelMembers ChannelMember[]
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 }
 
 model Message {
@@ -224,7 +246,7 @@ model Asset {
   id        String    @id @default(uuid()) @db.Uuid
   messageId String    @db.Uuid
   message   Message   @relation(fields: [messageId], references: [id])
-  // アセットの代替テキスト。画像の場合はalt属性に相当
+  /// アセットの代替テキスト。画像の場合はalt属性に相当
   alt       String?
   type      AssetType
   url       String
@@ -255,9 +277,9 @@ model PinnedMessage {
   @@id([channelId, messageId, pinnedBy])
 }
 
-/*
-ユーザーが個人的にメッセージを保存しておくためのブックマーク機能に使用するテーブル
-*/
+/**
+ * ユーザーが個人的にメッセージを保存しておくためのブックマーク機能に使用するテーブル
+ */
 model Bookmark {
   userId    String   @db.Uuid
   user      User     @relation(fields: [userId], references: [id])

--- a/prisma/seed/init.ts
+++ b/prisma/seed/init.ts
@@ -243,13 +243,29 @@ async function main() {
   // general チャンネル
   await prisma.channelMember.createMany({
     data: [
-      { channelId: generalChannel.id, userId: adminUser.id, role: "ADMIN" },
-      { channelId: generalChannel.id, userId: modUser.id, role: "MEMBER" },
-      { channelId: generalChannel.id, userId: memberUser.id, role: "MEMBER" },
+      {
+        channelId: generalChannel.id,
+        userId: adminUser.id,
+        role: "ADMIN",
+        displayOrder: 0,
+      },
+      {
+        channelId: generalChannel.id,
+        userId: modUser.id,
+        role: "MEMBER",
+        displayOrder: 0,
+      },
+      {
+        channelId: generalChannel.id,
+        userId: memberUser.id,
+        role: "MEMBER",
+        displayOrder: 0,
+      },
       {
         channelId: generalChannel.id,
         userId: anotherMemberUser.id,
         role: "MEMBER",
+        displayOrder: 0,
       },
     ],
   });
@@ -257,16 +273,36 @@ async function main() {
   // random チャンネル
   await prisma.channelMember.createMany({
     data: [
-      { channelId: randomChannel.id, userId: modUser.id, role: "MEMBER" },
-      { channelId: randomChannel.id, userId: memberUser.id, role: "MEMBER" },
+      {
+        channelId: randomChannel.id,
+        userId: modUser.id,
+        role: "MEMBER",
+        displayOrder: 1,
+      },
+      {
+        channelId: randomChannel.id,
+        userId: memberUser.id,
+        role: "MEMBER",
+        displayOrder: 1,
+      },
     ],
   });
 
   // private チャンネル
   await prisma.channelMember.createMany({
     data: [
-      { channelId: privateChannel.id, userId: adminUser.id, role: "ADMIN" },
-      { channelId: privateChannel.id, userId: modUser.id, role: "MEMBER" },
+      {
+        channelId: privateChannel.id,
+        userId: adminUser.id,
+        role: "ADMIN",
+        displayOrder: 2,
+      },
+      {
+        channelId: privateChannel.id,
+        userId: modUser.id,
+        role: "MEMBER",
+        displayOrder: 2,
+      },
     ],
   });
 }

--- a/src/app/_components/Accordion.tsx
+++ b/src/app/_components/Accordion.tsx
@@ -1,53 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
 import { Accordion as MantineAccordion } from "@mantine/core";
 import { IconChevronRight } from "@tabler/icons-react";
+import { useSession } from "next-auth/react";
 
 import styles from "./Accordion.module.css";
 import AccordionItem, { AccordionItemProps } from "./AccordionItem";
 
-const categories: AccordionItemProps[] = [
-  {
-    categoryName: "General",
-    channels: [
-      { title: "announcements", id: "1" },
-      { title: "random", id: "2" },
-      { title: "welcome", id: "3" },
-    ],
-  },
-  {
-    categoryName: "Development",
-    channels: [
-      { title: "frontend", id: "4" },
-      { title: "backend", id: "5" },
-      { title: "devops", id: "6" },
-    ],
-  },
-  {
-    categoryName: "Design",
-    channels: [
-      { title: "ui", id: "7" },
-      { title: "ux", id: "8" },
-      { title: "branding", id: "9" },
-    ],
-  },
-  {
-    categoryName: "Marketing",
-    channels: [
-      { title: "seo", id: "10" },
-      { title: "social media", id: "11" },
-      { title: "content", id: "12" },
-    ],
-  },
-  {
-    categoryName: "Support",
-    channels: [
-      { title: "help", id: "13" },
-      { title: "questions", id: "14" },
-      { title: "feedback", id: "15" },
-    ],
-  },
-];
+import { getCategories } from "#/libs/actions";
 
 const Accordion = () => {
+  const [accordionItems, setAccordionItems] = useState<AccordionItemProps[]>(
+    []
+  );
+
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      if (!session || !session.user.id) return;
+
+      try {
+        const result = await getCategories(session.user.id);
+
+        if (!result) throw new Error("チャンネル一覧の取得に失敗しました");
+
+        setAccordionItems([
+          {
+            name: "チャンネル",
+            channelMembers: result.uncategorizedChannelMembers,
+          },
+          ...result.categories.map((category) => {
+            return {
+              name: category.name,
+              channelMembers: category.channelMembers,
+            } satisfies AccordionItemProps;
+          }),
+        ]);
+      } catch {
+        setAccordionItems([]);
+      }
+    };
+
+    void fetchCategories();
+  }, [session]);
+
   return (
     <MantineAccordion
       multiple
@@ -63,11 +62,11 @@ const Accordion = () => {
       }}
       chevron={<IconChevronRight size={20} />}
     >
-      {categories.map((category) => (
+      {accordionItems.map((category) => (
         <AccordionItem
-          key={category.categoryName}
-          channels={category.channels}
-          categoryName={category.categoryName}
+          key={category.name}
+          channelMembers={category.channelMembers}
+          name={category.name}
         />
       ))}
     </MantineAccordion>

--- a/src/app/_components/Accordion.tsx
+++ b/src/app/_components/Accordion.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import { Loader, Accordion as MantineAccordion } from "@mantine/core";
+import { Accordion as MantineAccordion } from "@mantine/core";
 import { IconChevronRight } from "@tabler/icons-react";
 import { useSession } from "next-auth/react";
 
@@ -15,7 +15,6 @@ const Accordion = () => {
   const [accordionItems, setAccordionItems] = useState<AccordionItemProps[]>(
     []
   );
-  const [isLoading, setIsLoading] = useState(true);
 
   const { data: session } = useSession();
 
@@ -23,7 +22,6 @@ const Accordion = () => {
     const fetchCategories = async () => {
       if (!session || !session.user.id) return;
 
-      setIsLoading(true);
       try {
         const result = await getChannelAccordionItems(session.user.id);
 
@@ -32,15 +30,11 @@ const Accordion = () => {
         setAccordionItems(result);
       } catch {
         setAccordionItems([]);
-      } finally {
-        setIsLoading(false);
       }
     };
 
     void fetchCategories();
   }, [session]);
-
-  if (isLoading) return <Loader color="#FFFA" size="sm" m="auto" />;
 
   return (
     <MantineAccordion

--- a/src/app/_components/Accordion.tsx
+++ b/src/app/_components/Accordion.tsx
@@ -1,40 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { Accordion as MantineAccordion } from "@mantine/core";
 import { IconChevronRight } from "@tabler/icons-react";
-import { useSession } from "next-auth/react";
 
 import styles from "./Accordion.module.css";
-import AccordionItem, { AccordionItemProps } from "./AccordionItem";
-
-import { getChannelAccordionItems } from "#/libs/actions";
+import AccordionItem from "./AccordionItem";
+import { useChannelsAccordion } from "./ChannelsAccordionProvider";
 
 const Accordion = () => {
-  const [accordionItems, setAccordionItems] = useState<AccordionItemProps[]>(
-    []
-  );
-
-  const { data: session } = useSession();
+  const { accordionItems, refreshChannelList } = useChannelsAccordion();
 
   useEffect(() => {
-    const fetchCategories = async () => {
-      if (!session || !session.user.id) return;
-
-      try {
-        const result = await getChannelAccordionItems(session.user.id);
-
-        if (!result) throw new Error("チャンネル一覧の取得に失敗しました");
-
-        setAccordionItems(result);
-      } catch {
-        setAccordionItems([]);
-      }
-    };
-
-    void fetchCategories();
-  }, [session]);
+    refreshChannelList();
+  }, [refreshChannelList]);
 
   return (
     <MantineAccordion

--- a/src/app/_components/AccordionItem.tsx
+++ b/src/app/_components/AccordionItem.tsx
@@ -10,35 +10,32 @@ import { IconWorld } from "@tabler/icons-react";
 
 import styles from "./AccordionItem.module.css";
 
-export type AccordionItemType = {
-  title: string;
-  id: string;
-};
+import { ChannelMemberWithChannel } from "#/types/prisma";
 
 export type AccordionItemProps = {
-  categoryName: string;
-  channels: AccordionItemType[];
+  name: string;
+  channelMembers: ChannelMemberWithChannel[];
 };
 
 const AccordionItem: React.FC<AccordionItemProps> = ({
-  categoryName,
-  channels,
+  name,
+  channelMembers,
 }) => {
   return (
-    <MantineAccordionItem value={categoryName}>
-      <AccordionControl>{categoryName}</AccordionControl>
+    <MantineAccordionItem value={name}>
+      <AccordionControl>{name}</AccordionControl>
       <AccordionPanel>
         <ul className={styles.List}>
-          {channels.map((item) => (
-            <li key={item.id}>
+          {channelMembers.map((item) => (
+            <li key={item.channelId}>
               <Button
                 radius={0}
                 className={styles.Channel}
                 component={Link}
-                href={`/channels/${item.id}`}
+                href={`/channels/${item.channelId}`}
                 leftSection={<IconWorld size={20} />}
               >
-                {item.title}
+                {item.channel.slug}
               </Button>
             </li>
           ))}

--- a/src/app/_components/ChannelsAccordionProvider.tsx
+++ b/src/app/_components/ChannelsAccordionProvider.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  useTransition,
+} from "react";
+
+import { useSession } from "next-auth/react";
+
+import { AccordionItemProps } from "./AccordionItem";
+
+import { getChannelAccordionItems } from "#/libs/actions";
+
+type ChannelsAccordionContextType = {
+  refreshChannelList: () => void;
+  accordionItems: AccordionItemProps[];
+  isPending: boolean;
+};
+
+type ChannelsAccordionProviderProps = {
+  children?: React.ReactNode;
+};
+
+/**
+ * 参加中チャンネルのリストおよび、それを更新するためのメソッドを共有するためのコンテキスト
+ */
+export const ChannelsAccordionContext = createContext<
+  ChannelsAccordionContextType | undefined
+>(undefined);
+
+/**
+ * 参加中チャンネルのリストおよび、それを更新するためのメソッドをコンテキストから取得する
+ * @throws ChannelsAccordionProvider の外で使用された場合 Error を throw
+ * @returns コンテキストオブジェクト
+ */
+export const useChannelsAccordion = () => {
+  const channelsAccordionContext = useContext(ChannelsAccordionContext);
+
+  if (!channelsAccordionContext) {
+    throw new Error(
+      "useChannelsAccordion must be used within an ChannelsAccordionProvider"
+    );
+  }
+
+  return channelsAccordionContext;
+};
+
+/**
+ * ChannelsAccordionContextのプロバイダ \
+ * session を利用するため、 SessionProvider の子要素として配置する必要がある
+ */
+const ChannelsAccordionProvider = ({
+  children,
+}: ChannelsAccordionProviderProps) => {
+  const [isPending, startTransition] = useTransition();
+  const [accordionItems, setAccordionItems] = useState<AccordionItemProps[]>(
+    []
+  );
+  const { data: session } = useSession();
+
+  /**
+   * 参加中チャンネルのリストを更新する
+   */
+  const refreshChannelList = useCallback(
+    () =>
+      startTransition(async () => {
+        if (!session || !session.user.id) return;
+
+        try {
+          const result = await getChannelAccordionItems(session.user.id);
+          if (!result) throw new Error("チャンネル一覧の取得に失敗しました");
+          startTransition(() => {
+            setAccordionItems(result);
+          });
+        } catch {
+          startTransition(() => {
+            setAccordionItems([]);
+          });
+        }
+      }),
+    [session]
+  );
+
+  return (
+    <ChannelsAccordionContext.Provider
+      value={{
+        accordionItems,
+        refreshChannelList,
+        isPending,
+      }}
+    >
+      {children}
+    </ChannelsAccordionContext.Provider>
+  );
+};
+
+export default ChannelsAccordionProvider;

--- a/src/app/channels/[channel_id]/_components/ChannelFooter/ChannelFooter.tsx
+++ b/src/app/channels/[channel_id]/_components/ChannelFooter/ChannelFooter.tsx
@@ -8,6 +8,7 @@ import TextEditor from "../TextEditor/TextEditor";
 
 import styles from "./ChannelFooter.module.css";
 
+import { useChannelsAccordion } from "#/app/_components/ChannelsAccordionProvider";
 import { joinChannel } from "#/libs/actions";
 
 type ChannelFooterProps = {
@@ -22,11 +23,13 @@ const ChannelFooter: React.FC<ChannelFooterProps> = ({
   is_joined,
 }) => {
   const [isPending, startTransition] = useTransition();
+  const { refreshChannelList } = useChannelsAccordion();
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     startTransition(async () => {
       await joinChannel(channel_id, user_id);
+      refreshChannelList(); // 参加処理後、メニュー上の参加中チャンネル一覧を更新する
     });
   };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { SessionProvider } from "next-auth/react";
 import "@mantine/code-highlight/styles.css";
 import "@mantine/core/styles.css";
 import AppShell from "./_components/AppShell";
+import ChannelsAccordionProvider from "./_components/ChannelsAccordionProvider";
 import "./globals.css";
 
 dayjs.extend(utc);
@@ -37,7 +38,9 @@ export default function RootLayout({ children }: RootRayoutProps) {
       <body>
         <SessionProvider>
           <MantineProvider>
-            <AppShell>{children}</AppShell>
+            <ChannelsAccordionProvider>
+              <AppShell>{children}</AppShell>
+            </ChannelsAccordionProvider>
           </MantineProvider>
         </SessionProvider>
       </body>

--- a/src/libs/actions.ts
+++ b/src/libs/actions.ts
@@ -6,6 +6,9 @@ import { prisma } from "./prisma";
 
 import type { Asset, MessageType } from "@prisma/client";
 
+import { getCategoriesWithChannelMembersWithChannel } from "#/repositories/channelCategory";
+import { getUncategorizedChannelMembersWithChannel } from "#/repositories/channelMember";
+
 type SearchChannelsProps = {
   keyword: string;
 };
@@ -47,11 +50,22 @@ export async function joinChannel(channelId: string, userId: string) {
     throw new Error("User not found");
   }
 
+  const lastChannelMember = await prisma.channelMember.findFirst({
+    where: {
+      userId,
+    },
+    orderBy: {
+      displayOrder: "desc",
+    },
+  });
+
+  // デフォルトカテゴリの最後尾に追加
   await prisma.channelMember.create({
     data: {
       channelId: channel.id,
       userId: user.id,
       role: "MEMBER",
+      displayOrder: lastChannelMember ? lastChannelMember.displayOrder + 1 : 0,
     },
   });
 
@@ -103,4 +117,28 @@ export async function sendMessage(props: SendMessageProps) {
   });
 
   revalidatePath(`/channels/${channel.id}`);
+}
+
+export async function getCategories(userId: string) {
+  const workspace = await prisma.workspace.findFirst({
+    where: {
+      users: {
+        some: {
+          userId,
+        },
+      },
+    },
+  });
+
+  if (!workspace) return null;
+
+  const [uncategorizedChannelMembers, categories] = await Promise.all([
+    getUncategorizedChannelMembersWithChannel(userId, workspace.id),
+    getCategoriesWithChannelMembersWithChannel(userId, workspace.id),
+  ]);
+
+  return {
+    uncategorizedChannelMembers,
+    categories,
+  };
 }

--- a/src/libs/actions.ts
+++ b/src/libs/actions.ts
@@ -54,6 +54,7 @@ export async function joinChannel(channelId: string, userId: string) {
   const lastChannelMember = await prisma.channelMember.findFirst({
     where: {
       userId,
+      categoryId: null, // Ensure we only fetch members from the default category
     },
     orderBy: {
       displayOrder: "desc",

--- a/src/repositories/channelCategory.ts
+++ b/src/repositories/channelCategory.ts
@@ -1,0 +1,36 @@
+import { ChannelCategory, PrismaPromise } from "@prisma/client";
+
+import { prisma } from "#/libs/prisma";
+import { ChannelMemberWithChannel } from "#/types/prisma";
+
+/**
+ * 指定したユーザーのチャンネルカテゴリおよび、カテゴリに紐づけられた参加チャンネルを取得
+ * @param userId
+ * @param workspaceId
+ * @returns チャンネルカテゴリのリスト (ChannelCategory & {channelMembers: ChannelMemberWithChannel[]})
+ */
+export const getCategoriesWithChannelMembersWithChannel = (
+  userId: string,
+  workspaceId: string
+): PrismaPromise<
+  (ChannelCategory & {
+    channelMembers: ChannelMemberWithChannel[];
+  })[]
+> => {
+  return prisma.channelCategory.findMany({
+    where: {
+      userId,
+      workspaceId,
+    },
+    include: {
+      channelMembers: {
+        include: {
+          channel: true,
+        },
+        orderBy: {
+          displayOrder: "asc",
+        },
+      },
+    },
+  });
+};

--- a/src/repositories/channelMember.ts
+++ b/src/repositories/channelMember.ts
@@ -1,0 +1,31 @@
+import { PrismaPromise } from "@prisma/client";
+
+import { prisma } from "#/libs/prisma";
+import { ChannelMemberWithChannel } from "#/types/prisma";
+
+/**
+ * 選択したユーザーの参加チャンネルのうち、チャンネルカテゴリを登録していないチャンネルを取得
+ * @param userId
+ * @param workspaceId
+ * @returns チャンネルのリスト (ChannelMemberWithChannel)
+ */
+export const getUncategorizedChannelMembersWithChannel = (
+  userId: string,
+  workspaceId: string
+): PrismaPromise<ChannelMemberWithChannel[]> => {
+  return prisma.channelMember.findMany({
+    where: {
+      userId,
+      channel: {
+        workspaceId,
+      },
+      categoryId: null,
+    },
+    include: {
+      channel: true,
+    },
+    orderBy: {
+      displayOrder: "asc",
+    },
+  });
+};

--- a/src/types/prisma.ts
+++ b/src/types/prisma.ts
@@ -1,4 +1,4 @@
-import { Account, User } from "@prisma/client";
+import { Account, Channel, ChannelMember, User } from "@prisma/client";
 
 export type UserWithAccounts = User & {
   accounts: Account[];
@@ -8,3 +8,7 @@ export type EditableUserParams = Pick<
   User,
   "image" | "name" | "slug" | "description"
 >;
+
+export type ChannelMemberWithChannel = ChannelMember & {
+  channel: Channel;
+};


### PR DESCRIPTION
## 関連 Issue(s)

<!--
`Close #123` のように記載することで、merge と同時に対応する Issue を自動で close できます。

複数の Issue に関連する場合は、箇条書きで列挙してください。
-->

## 変更内容

<!--
この Pull Request の目的や変更内容を簡潔に説明してください。
-->

- 参加中チャンネルを取得・サイドメニューに表示する機能を実装
  - 既存のチャンネル参加処理に、処理後メニュー上のチャンネルリストも更新する処理を追加
- 参加中チャンネルの表示順・カテゴリを保持できるようスキーマを変更
  - 将来的に並び替えやフォルダ分けが実装できる予定

### スクリーンショット

<!--
必要に応じて、変更内容を示すスクリーンショットも添付してください。

UI を変更する（見た目が変わる）場合は、必ず追加してください。
-->

![image](https://github.com/user-attachments/assets/517bf526-5ab3-4359-9e0f-e8d5b9d6af6b)

## 確認手順

<!--
変更内容が正しく動作することを確認する手順を番号付きの箇条書きで記載してください。
-->

1. マイグレーションを更新する (要リセット)
2. ログイン後、適当なチャンネルページを開く
3. フッターの「参加する」ボタンを押す
4. 左のメニュー上に参加したチャンネルが表示される